### PR TITLE
Update fbstripasalias.snippet.php

### DIFF
--- a/core/components/formblocks/elements/snippets/fbstripasalias.snippet.php
+++ b/core/components/formblocks/elements/snippets/fbstripasalias.snippet.php
@@ -1,7 +1,7 @@
 <?php
 $input = strip_tags($input); // strip HTML
 $input = strtolower($input); // convert to lowercase
-$input = preg_replace('/[^\.A-Za-z0-9 _-]/', '', $input); // strip non-alphanumeric characters
+$input = preg_replace('/[^A-Za-z0-9 _-]/', '', $input); // strip non-alphanumeric characters
 $input = preg_replace('/\s+/', '-', $input); // convert white-space to dash
 $input = preg_replace('/-+/', '-', $input);  // convert multiple dashes to one
 $input = trim($input, '-'); // trim excess


### PR DESCRIPTION
While HTML5 allows for the presence of the "." character in the name attribute, formit uses modX::setPlaceholders() to populate the form report placeholders with the form submission, which seems to choke on them. This change allows for using periods in formblocks field labels.
